### PR TITLE
Automatically keep balance up to date

### DIFF
--- a/scripts/database.ts
+++ b/scripts/database.ts
@@ -2,6 +2,7 @@ import Dexie from "dexie";
 
 export class AppDatabase extends Dexie {
     static active_profile_key = "profile.active";
+    static balance_update_time_key = "job.balance_update"
 
     static instance: AppDatabase = new AppDatabase();
 


### PR DESCRIPTION
Closes #55 

 - Updates the balance whenver the tab is refocused. This should update the balance whenever the user reopens the app.
 - Periodically updates the balance status (every 10 seconds).